### PR TITLE
feat(litestream): set up disaster-recovery with litestream

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # linkstack
 
-[![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-yellow.svg)](https://www.gnu.org/licenses/agpl-3.0)
-[![Release Charts](https://github.com/thylong/linkstack-chart/actions/workflows/release.yml/badge.svg)](https://github.com/thylong/linkstack-chart/actions/workflows/release.yml)
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.16.0](https://img.shields.io/badge/AppVersion-1.16.0-informational?style=flat-square)
 
 A LinkStack unofficial Helm chart
 
@@ -13,31 +11,16 @@ The chart currently supports:
 - Basic setup with mysql as backend
 - PersistentVolume to store data
 
-## Usage
+## Getting Started
 
-[Helm](https://helm.sh) must be installed to use the charts.  Please refer to
-Helm's [documentation](https://helm.sh/docs) to get started.
+### Requirement
 
-Once Helm has been set up correctly, add the repo as follows:
+Helm (version >= 3) and a functional kubernetes cluster (>=1.24) are the sole dependencies.
 
-```bash
-helm repo add linkstack http://thylong.com/linkstack-chart/
-```
-
-If you had already added this repo earlier, run `helm repo update` to retrieve
-the latest versions of the packages.  You can then run `helm search repo
-linkstack` to see the charts.
-
-### Install
+### Basic install
 
 ```bash
 helm install -f values.yaml linkstack .
-```
-
-### Uninstall
-
-```bash
-helm uninstall linkstack
 ```
 
 ## Features considered
@@ -57,22 +40,22 @@ helm uninstall linkstack
 | affinity | object | `{}` | Affinity rules to constrain pod scheduling to specific node(s) matching rules. |
 | autoscaling | object | `{"enabled":false,"maxReplicas":10,"minReplicas":1,"targetCPUUtilizationPercentage":80}` | HPA rules. |
 | fullnameOverride | string | `""` |  |
-| image.pullPolicy | string | `"IfNotPresent"` |  |
-| image.repository | string | `"linkstackorg/linkstack"` |  |
-| image.tag | string | `"latest"` |  |
 | ingress.annotations | object | `{}` |  |
 | ingress.className | string | `""` | Name of the ingress class to route through this application |
 | ingress.enabled | bool | `false` |  |
-| linkstack | object | `{"backend":"sqlite","env":{"log_level":"info","php_memory_limit":"512M","tz":"Europe/Paris","upload_max_filesize":"8M"}}` | Linkstack specific configuration |
+| linkstack | object | `{"backend":"sqlite","env":{"log_level":"info","php_memory_limit":"512M","tz":"Europe/Paris","upload_max_filesize":"8M"},"image":{"pullPolicy":"IfNotPresent","repository":"linkstackorg/linkstack","tag":"latest"},"resources":{"limits":{"cpu":"250m","memory":"512Mi"},"requests":{"cpu":"250m","memory":"512Mi"}},"volumeMounts":[{"mountPath":"/htdocs","name":"linkstack-sqlite","readOnly":false}]}` | Linkstack container specific configuration |
 | linkstack.backend | string | `"sqlite"` | Datastore to use (either sqlite or mysql) |
+| linkstack.resources.limits.memory | string | `"512Mi"` | PHP_MEMORY_LIMIT should be adjusted accordingly |
+| linkstack.volumeMounts | list | `[{"mountPath":"/htdocs","name":"linkstack-sqlite","readOnly":false}]` | Additional volumeMounts on the output Deployment definition. |
+| litestream | object | `{"image":{"pullPolicy":"IfNotPresent","repository":"litestream/litestream","tag":"latest"},"limits":{"cpu":"250m","memory":"256Mi"},"path":"/htdocs/database/database.sqlite","region":"eu-west-1","requests":{"cpu":"125m","memory":"128Mi"},"skipVerify":true,"url":"s3://linkstack-backup-prod-eu/litestream","volumeMounts":[{"mountPath":"/etc/litestream.yml","name":"linkstack-litestream","subPath":"litestream.yml"}]}` | Litestream sidecar specific configuration (sqlite disaster-recovery tool) This configuration won't be used if sqlite is not selected as backend. |
 | nameOverride | string | `""` |  |
+| namespace | string | `""` | Specifies in which namespace linkstack release should be deployed Will be deployed to the default namespace if not specified |
+| networkPolicy | object | `{"enabled":false,"ports":[{"port":443},{"port":80}]}` | Restrict network permissions using Kubernetes L4 network policies |
 | nodeSelector | object | `{}` | Assign pods to nodes matching specific label. |
 | podAnnotations | object | `{}` |  |
 | podLabels | object | `{}` |  |
 | podSecurityContext | object | `{}` |  |
 | replicaCount | int | `1` | Number of linkstack pods |
-| resources | object | `{"limits":{"cpu":"250m","memory":"512Mi"},"requests":{"cpu":"250m","memory":"512Mi"}}` | The following values aligned with linkstack default PHP values. |
-| resources.limits.memory | string | `"512Mi"` | PHP_MEMORY_LIMIT should be adjusted accordingly |
 | securityContext | object | `{}` |  |
 | service.port | int | `80` |  |
 | service.type | string | `"ClusterIP"` |  |
@@ -81,8 +64,7 @@ helm uninstall linkstack
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
 | serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
 | tolerations | list | `[]` | Tolerations lift taint constraints with a tradeoff on scheduling guarantees. |
-| volumeMounts | list | `[{"mountPath":"/htdocs","name":"linkstack-sqlite","readOnly":false}]` | Additional volumeMounts on the output Deployment definition. |
-| volumes | list | `[{"name":"linkstack-sqlite","persistentVolumeClaim":{"claimName":"linkstack-sqlite-pvc"}}]` | Additional volumes on the output Deployment definition. |
+| volumes | list | `[{"name":"linkstack-sqlite","persistentVolumeClaim":{"claimName":"linkstack-sqlite-pvc"}},{"configMap":{"name":"linkstack-litestream"},"name":"linkstack-litestream"}]` | Additional volumes on the output Deployment definition. |
 
 ## License
 

--- a/templates/configmap-litestream.yaml
+++ b/templates/configmap-litestream.yaml
@@ -1,0 +1,22 @@
+{{- if contains "sqlite" .Values.linkstack.backend }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "linkstack.fullname" . }}-litestream
+  {{- if ne .Values.namespace "" }}
+  namespace: {{ .Values.namespace }}
+  {{- end }}
+  labels:
+    {{- include "linkstack.labels" . | nindent 4 }}
+  # annotations:
+  #   "helm.sh/hook": pre-install
+  #   "helm.sh/hook-weight": "-5"
+data:
+  litestream.yml: |-
+    dbs:
+      - path: {{ .Values.litestream.path }}
+        replicas:
+          - url: {{ .Values.litestream.url }}
+            region: {{ .Values.litestream.region }}
+            skip-verify: {{ .Values.litestream.skipVerify }}
+{{- end }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -31,7 +31,9 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       initContainers:
         - name: cp
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.linkstack.image.repository }}:{{ .Values.linkstack.image.tag | default .Chart.AppVersion }}"
+          resources:
+            {{- toYaml .Values.linkstack.resources | nindent 12 }}
           command: ["/bin/ash", "-c", "sleep 1 && \
           cp -Ra /htdocs/. /htdocs_provisioning/ && \
           chown -R apache:apache /htdocs_provisioning && \
@@ -44,8 +46,8 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          image: "{{ .Values.linkstack.image.repository }}:{{ .Values.linkstack.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.linkstack.image.pullPolicy }}
           env:
           {{- range $key, $value := .Values.linkstack.env }}
           - name: {{ $key | upper | replace "." "_" }}
@@ -64,11 +66,36 @@ spec:
               path: /
               port: http
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
-          {{- with .Values.volumeMounts }}
+            {{- toYaml .Values.linkstack.resources | nindent 12 }}
+          {{- with .Values.linkstack.volumeMounts }}
           volumeMounts:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+        {{- if contains "sqlite" .Values.linkstack.backend }}
+        - name: litestream
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.litestream.image.repository }}:{{ .Values.litestream.image.tag | default "latest" }}"
+          imagePullPolicy: {{ .Values.litestream.pullPolicy }}
+          resources:
+            {{- toYaml .Values.litestream.resources | nindent 12 }}
+          args: ["replicate"]
+          env:
+          - name: LITESTREAM_ACCESS_KEY_ID
+            valueFrom:
+              secretKeyRef:
+                name: litestream
+                key: LITESTREAM_ACCESS_KEY_ID
+          - name: LITESTREAM_SECRET_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                name: litestream
+                key: LITESTREAM_SECRET_ACCESS_KEY
+          {{- with .Values.litestream.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+        {{- end }}
       {{- with .Values.volumes }}
       volumes:
         {{- toYaml . | nindent 8 }}

--- a/values.yaml
+++ b/values.yaml
@@ -1,8 +1,14 @@
-# Default values for linkstack.
-# This is a YAML-formatted file.
-# Declare variables to be passed into your templates.
+# -- Specifies in which namespace linkstack release should be deployed
+# Will be deployed to the default namespace if not specified
+namespace: ""
 
-# -- Linkstack specific configuration
+nameOverride: ""
+fullnameOverride: ""
+
+# -- (int) Number of linkstack pods
+replicaCount: 1
+
+# -- Linkstack container specific configuration
 linkstack:
   # -- Datastore to use (either sqlite or mysql)
   backend: sqlite
@@ -14,21 +20,55 @@ linkstack:
     # http_server_name: 'example.com'
     # https_server_name: 'example.com'
     log_level: 'info'
+  image:
+    repository: linkstackorg/linkstack
+    pullPolicy: IfNotPresent
+    tag: "latest"
+  resources:
+    limits:
+      cpu: 250m
+      # -- PHP_MEMORY_LIMIT should be adjusted accordingly
+      memory: 512Mi
+    requests:
+      cpu: 250m
+      memory: 512Mi
+  # -- Additional volumeMounts on the output Deployment definition.
+  volumeMounts:
+    - name: linkstack-sqlite
+      mountPath: "/htdocs"
+      # SQLite & assets storage requires both RW permissions.
+      readOnly: false
 
-# -- Specifies in which namespace linkstack release should be deployed
-# Will be deployed to the default namespace if not specified
-namespace: ""
+# -- Litestream sidecar specific configuration (sqlite disaster-recovery tool)
+# This configuration won't be used if sqlite is not selected as backend.
+litestream:
+  image:
+    repository: litestream/litestream
+    pullPolicy: IfNotPresent
+    tag: "latest"
+  limits:
+    cpu: 250m
+    memory: 256Mi
+  requests:
+    cpu: 125m
+    memory: 128Mi
+  path: /htdocs/database/database.sqlite
+  url: "s3://linkstack-backup-prod-eu/litestream"
+  region: "eu-west-1"
+  skipVerify: true
+  volumeMounts:
+    - name: linkstack-litestream
+      mountPath: /etc/litestream.yml
+      subPath: litestream.yml
 
-nameOverride: ""
-fullnameOverride: ""
-
-# -- (int) Number of linkstack pods
-replicaCount: 1
-
-image:
-  repository: linkstackorg/linkstack
-  pullPolicy: IfNotPresent
-  tag: "latest"
+# -- Additional volumes on the output Deployment definition.
+volumes:
+  - name: linkstack-sqlite
+    persistentVolumeClaim:
+      claimName: linkstack-sqlite-pvc
+  - name: linkstack-litestream
+    configMap:
+      name: linkstack-litestream
 
 serviceAccount:
   # -- Specifies whether a service account should be created
@@ -41,10 +81,16 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
-podAnnotations: {}
-podLabels: {}
+service:
+  type: ClusterIP
+  port: 80
 
-podSecurityContext: {}
+# -- Restrict network permissions using Kubernetes L4 network policies
+networkPolicy:
+  enabled: false
+  ports:
+    - port: 443
+    - port: 80
 
 securityContext: {}
 #   capabilities:
@@ -57,16 +103,10 @@ securityContext: {}
 # fsGroup: 101
 # readOnlyRootFilesystem: true
 
-# -- Restrict network permissions using Kubernetes L4 network policies
-networkPolicy:
-  enabled: false
-  ports:
-    - port: 443
-    - port: 80
+podAnnotations: {}
+podLabels: {}
 
-service:
-  type: ClusterIP
-  port: 80
+podSecurityContext: {}
 
 ingress:
   enabled: false
@@ -83,16 +123,6 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
-# -- The following values aligned with linkstack default PHP values.
-resources:
-  limits:
-    cpu: 250m
-    # -- PHP_MEMORY_LIMIT should be adjusted accordingly
-    memory: 512Mi
-  requests:
-    cpu: 250m
-    memory: 512Mi
-
 # -- HPA rules.
 autoscaling:
   enabled: false
@@ -100,19 +130,6 @@ autoscaling:
   maxReplicas: 10
   targetCPUUtilizationPercentage: 80
   # targetMemoryUtilizationPercentage: 80
-
-# -- Additional volumes on the output Deployment definition.
-volumes:
-  - name: linkstack-sqlite
-    persistentVolumeClaim:
-      claimName: linkstack-sqlite-pvc
-
-# -- Additional volumeMounts on the output Deployment definition.
-volumeMounts:
-  - name: linkstack-sqlite
-    mountPath: "/htdocs"
-    # SQLite & assets storage requires both RW permissions.
-    readOnly: false
 
 # -- Assign pods to nodes matching specific label.
 nodeSelector: {}


### PR DESCRIPTION
# Context

Even if persisted on a PersistentVolume, sqlite file gets flushed in many disaster scenarios.
As a simple, yet efficient disaster recovery procedure, [litestream](https://litestream.io) will be included in this PR.

Among the candidates to make this chart more resilient was considered as well [rqlite](https://rqlite.io/).
As this tool is extremely powerful but increase as well the complexity, it wasn't selected for the moment.

## Next steps
[Litestream favors StatefulSet over Deployment](https://litestream.io/guides/kubernetes/) for Litestream to guarantee there is a single litestream instance running at all time.
The chart should probably be split into a library chart with common templates and a subchart for each backend (MySQL, SQLite, etc).

**For the moment, this chart will focus more on simplicity rather than consistency**.